### PR TITLE
Add unit tests for validation modules and schema validation

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,202 +6,209 @@ Ce répertoire contient tous les tests unitaires pour le projet.
 
 ```
 test/
-├── __init__.py           # Initialisation du package de tests
-├── test_extract.py       # Tests pour les fonctions d'extraction (src/etl/extract.py)
-├── test_transform.py     # Tests pour les fonctions de transformation (src/etl/transform.py)
-├── test_load.py          # Tests pour les fonctions de chargement (src/etl/load.py)
-└── README.md            # Ce fichier
+├── __init__.py              # Initialisation du package de tests
+├── README.md                # Ce fichier
+│
+├── # Tests ETL
+├── test_extract.py          # Tests pour src/etl/extract.py (load_config)
+├── test_transform.py        # Tests pour src/etl/transform.py
+├── test_load.py             # Tests pour src/etl/load.py (load_df_to_db)
+├── test_pipelines.py        # Tests pour src/etl/pipelines.py (pipeline_db_raw, pipeline_db_cleaned)
+│
+├── # Tests Validation
+├── test_validators.py       # Tests pour src/validation/validators.py (checks Pandera)
+├── test_schema_validation.py # Tests pour src/validation/schema_validation.py
+├── test_base.py             # Tests pour src/validation/base.py (ValidationMode, ValidationResult)
+├── test_integration.py      # Tests pour src/validation/integration.py (SchemaConverter)
+│
+└── # Exemples
+    └── test_utils.py        # Tests d'exemple pour apprendre (src/utils.py)
 ```
 
-## Installation des dépendances de test
+## Modules testés
 
-Les dépendances de test sont déjà incluses dans le `pyproject.toml`. Pour les installer:
+### ETL (src/etl/)
+| Fichier de test | Module testé | Fonctions testées |
+|-----------------|--------------|-------------------|
+| `test_extract.py` | `extract.py` | `load_config()` |
+| `test_load.py` | `load.py` | `load_df_to_db()` |
+| `test_pipelines.py` | `pipelines.py` | `pipeline_db_raw()`, `pipeline_db_cleaned()` |
+| `test_transform.py` | `transform.py` | (à compléter) |
+
+### Validation (src/validation/)
+| Fichier de test | Module testé | Fonctions/Classes testées |
+|-----------------|--------------|---------------------------|
+| `test_validators.py` | `validators.py` | `coordinates_check()`, `coordinates_in_france()`, `beaufort_scale_check()`, `douglas_scale_check()`, `departement_format_check()`, `resultat_humain_coherence()`, `flotteur_longueur_type_coherence()` |
+| `test_schema_validation.py` | `schema_validation.py` | `build_dataframe_schema()`, `valider_csv()` |
+| `test_base.py` | `base.py` | `ValidationMode`, `ValidationResult`, `EnumWarningCollector`, `create_enum_column()` |
+| `test_integration.py` | `integration.py` | `SchemaConverter`, `validate_for_crud()`, `validate_dataframe()` |
+
+## Installation des dépendances
 
 ```bash
+# Avec uv (recommandé)
 uv sync
-```
 
-ou si vous utilisez pip:
-
-```bash
+# Ou avec pip
 pip install -e .
 ```
 
 ## Exécution des tests
 
-### Exécuter tous les tests
+### Tous les tests
 ```bash
 pytest
 ```
 
-### Exécuter un fichier de test spécifique
+### Par module
+
 ```bash
-pytest test/test_extract.py
-pytest test/test_load.py
-pytest test/test_transform.py
+# Tests ETL
+pytest test/test_extract.py test/test_load.py test/test_pipelines.py -v
+
+# Tests Validation
+pytest test/test_validators.py test/test_schema_validation.py test/test_base.py test/test_integration.py -v
 ```
 
-### Exécuter une classe de test spécifique
+### Un fichier spécifique
 ```bash
-pytest test/test_extract.py::TestLoadConfig
-pytest test/test_load.py::TestLoadDfToDb
+pytest test/test_validators.py -v
 ```
 
-### Exécuter un test spécifique
+### Une classe spécifique
 ```bash
-pytest test/test_extract.py::TestLoadConfig::test_load_config_success
+pytest test/test_validators.py::TestBeaufortScaleCheck -v
 ```
 
-### Exécuter avec verbosité
+### Un test spécifique
 ```bash
-pytest -v
+pytest test/test_validators.py::TestBeaufortScaleCheck::test_valeur_valide_minimum -v
 ```
 
-### Exécuter avec rapport de couverture
+### Options utiles
 ```bash
-pytest --cov=src --cov-report=html
-```
-
-Le rapport HTML sera généré dans `htmlcov/index.html`
-
-### Exécuter avec capture de sortie désactivée (pour voir les prints)
-```bash
-pytest -s
-```
-
-### Exécuter uniquement les tests qui ont échoué la dernière fois
-```bash
-pytest --lf
-```
-
-### Exécuter en mode parallèle (plus rapide)
-```bash
-pytest -n auto
-```
-Note: nécessite `pytest-xdist` (à ajouter si besoin)
-
-## Markers personnalisés
-
-Les tests peuvent être marqués avec des markers personnalisés:
-
-- `@pytest.mark.slow` - Tests lents
-- `@pytest.mark.integration` - Tests d'intégration
-- `@pytest.mark.unit` - Tests unitaires
-
-### Exécuter uniquement certains types de tests
-```bash
-# Exécuter seulement les tests unitaires
-pytest -m unit
-
-# Exclure les tests lents
-pytest -m "not slow"
-
-# Exécuter les tests d'intégration
-pytest -m integration
+pytest -v              # Verbeux
+pytest -s              # Afficher les print()
+pytest -x              # S'arrêter au premier échec
+pytest --lf            # Relancer les tests échoués
+pytest --cov=src       # Couverture de code (nécessite pytest-cov)
 ```
 
 ## Couverture de code
 
-La configuration pytest est définie pour générer automatiquement des rapports de couverture:
+Pour générer un rapport de couverture (nécessite `pytest-cov`):
 
-- **Terminal**: Affiche le pourcentage de couverture après chaque exécution
-- **HTML**: Génère un rapport détaillé dans `htmlcov/`
-
-### Visualiser le rapport de couverture HTML
 ```bash
+# Installer pytest-cov si nécessaire
+pip install pytest-cov
+
+# Lancer avec couverture
 pytest --cov=src --cov-report=html
-open htmlcov/index.html  # Sur macOS
+
+# Ouvrir le rapport
+open htmlcov/index.html  # macOS
 ```
+
+## Résumé des tests par fichier
+
+### test_validators.py (30 tests)
+- `TestCoordinatesCheck` - 4 tests
+- `TestCoordinatesInFrance` - 4 tests
+- `TestBeaufortScaleCheck` - 6 tests
+- `TestDouglasScaleCheck` - 4 tests
+- `TestDepartementFormatCheck` - 6 tests
+- `TestResultatHumainCoherence` - 3 tests
+- `TestFlotteurLongueurTypeCoherence` - 3 tests
+
+### test_schema_validation.py (12 tests)
+- `TestBuildDataframeSchema` - 6 tests
+- `TestValiderCsv` - 2 tests
+- `TestTypeValidation` - 4 tests
+
+### test_base.py (18 tests)
+- `TestValidationMode` - 2 tests
+- `TestValidationResult` - 3 tests
+- `TestEnumWarningCollector` - 6 tests
+- `TestCreateEnumCheckWarning` - 2 tests
+- `TestCreateEnumColumn` - 5 tests
+
+### test_integration.py (17 tests)
+- `TestWidgetToPanderaMapping` - 4 tests
+- `TestSchemaConverter` - 6 tests
+- `TestValidateForCrud` - 3 tests
+- `TestValidateDataframe` - 2 tests
+- `TestValidationResultIntegration` - 2 tests
+
+### test_extract.py (2 tests)
+- `TestLoadConfig` - 2 tests
+
+### test_load.py (3 tests)
+- `TestLoadDfToDb` - 3 tests
+
+### test_pipelines.py (3 tests)
+- `TestPipelineDbRaw` - 2 tests
+- `TestPipelineDbCleaned` - 1 test
+
+### test_utils.py (3 tests)
+- Tests d'exemple pour apprendre
 
 ## Bonnes pratiques
 
-1. **Nommage**: Les fichiers de test doivent commencer par `test_`
-2. **Organisation**: Une classe de test par fonction ou groupe de fonctions liées
-3. **Isolation**: Chaque test doit être indépendant des autres
-4. **Fixtures**: Utilisez des fixtures pytest pour le code de setup réutilisable
-5. **Mocking**: Utilisez `unittest.mock` pour simuler les dépendances externes
-6. **Assertions**: Utilisez des assertions claires et descriptives
+1. **Structure AAA** : Arrange, Act, Assert
+2. **Un test = une chose** : Chaque test vérifie un seul comportement
+3. **Noms descriptifs** : `test_validation_echoue_si_champ_requis_vide`
+4. **Isolation** : Les tests ne dépendent pas les uns des autres
+5. **Mocks** : Simuler les dépendances externes (DB, API, fichiers)
 
-## Exemples de tests
+## Exemple de test simple
 
-### Test avec fixture
 ```python
-@pytest.fixture
-def sample_data():
-    return {"key": "value"}
+def test_addition():
+    # ARRANGE (Préparer)
+    a = 5
+    b = 3
 
-def test_example(sample_data):
-    assert sample_data["key"] == "value"
+    # ACT (Agir)
+    resultat = a + b
+
+    # ASSERT (Vérifier)
+    assert resultat == 8
 ```
 
-### Test avec mock
+## Exemple avec mock
+
 ```python
 from unittest.mock import patch, MagicMock
 
-@patch('module.function')
-def test_with_mock(mock_function):
-    mock_function.return_value = "mocked"
-    result = my_function()
-    assert result == "expected"
-```
+@patch('src.module.fonction_externe')
+def test_avec_mock(mock_fonction):
+    # Configurer le mock
+    mock_fonction.return_value = "valeur simulée"
 
-### Test avec exception
-```python
-def test_exception():
-    with pytest.raises(ValueError) as exc_info:
-        raise_error()
-    assert "error message" in str(exc_info.value)
+    # Appeler la fonction à tester
+    resultat = ma_fonction()
+
+    # Vérifier
+    mock_fonction.assert_called_once()
+    assert resultat == "valeur attendue"
 ```
 
 ## Dépannage
 
-### Les imports ne fonctionnent pas
-Assurez-vous d'être dans le répertoire racine du projet et que le package est installé:
+### ImportError
 ```bash
 pip install -e .
 ```
 
-### Les tests ne sont pas découverts
-Vérifiez que:
-- Les fichiers commencent par `test_`
-- Les classes commencent par `Test`
-- Les fonctions commencent par `test_`
-- Le fichier `__init__.py` existe dans le dossier `test/`
+### Tests non découverts
+Vérifier que:
+- Fichiers commencent par `test_`
+- Classes commencent par `Test`
+- Fonctions commencent par `test_`
+- `__init__.py` existe dans `test/`
 
-### Erreurs de dépendances
-Réinstallez les dépendances:
+### Erreur pytest-cov
 ```bash
-uv sync
-# ou
-pip install -e .
-```
-
-## Ajout de nouveaux tests
-
-Pour ajouter des tests pour un nouveau module:
-
-1. Créer un fichier `test_<nom_module>.py` dans ce dossier
-2. Importer le module à tester
-3. Créer des classes de test avec le préfixe `Test`
-4. Écrire des fonctions de test avec le préfixe `test_`
-5. Utiliser des assertions pour vérifier le comportement attendu
-
-Exemple:
-```python
-"""Tests pour mon_module"""
-import pytest
-from src.mon_module import ma_fonction
-
-class TestMaFonction:
-    """Tests pour ma_fonction"""
-
-    def test_cas_nominal(self):
-        """Test du cas nominal"""
-        result = ma_fonction(input_data)
-        assert result == expected_output
-
-    def test_cas_erreur(self):
-        """Test du cas d'erreur"""
-        with pytest.raises(ValueError):
-            ma_fonction(invalid_input)
+# Lancer sans couverture
+pytest --override-ini="addopts="
 ```

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,0 +1,285 @@
+"""
+Tests unitaires pour les classes de base de validation (src/validation/base.py)
+
+Ce module fournit les utilitaires pour créer des schémas Pandera.
+"""
+import pytest
+import pandas as pd
+import pandera as pa
+from pandera import Column
+
+from src.validation.base import (
+    ValidationMode,
+    ValidationResult,
+    EnumWarningCollector,
+    create_enum_check_warning,
+    create_enum_column,
+)
+
+
+# =============================================================================
+#                Tests pour ValidationMode (Enum)
+# =============================================================================
+
+class TestValidationMode:
+    """Tests pour l'enum ValidationMode"""
+
+    def test_mode_strict_existe(self):
+        """Test: le mode STRICT existe"""
+        assert ValidationMode.STRICT.value == "strict"
+
+    def test_mode_warning_existe(self):
+        """Test: le mode WARNING existe"""
+        assert ValidationMode.WARNING.value == "warning"
+
+
+# =============================================================================
+#                Tests pour ValidationResult (Dataclass)
+# =============================================================================
+
+class TestValidationResult:
+    """Tests pour la dataclass ValidationResult"""
+
+    def test_creation_resultat_valide(self):
+        """
+        Test 1: Création d'un résultat de validation valide
+        """
+        # ARRANGE & ACT
+        resultat = ValidationResult(
+            is_valid=True,
+            errors=[],
+            warnings=[],
+            validated_data=pd.DataFrame({'col': [1, 2]})
+        )
+
+        # ASSERT
+        assert resultat.is_valid is True
+        assert resultat.errors == []
+        assert resultat.warnings == []
+        assert resultat.validated_data is not None
+
+    def test_creation_resultat_invalide_avec_erreurs(self):
+        """
+        Test 2: Création d'un résultat avec des erreurs
+        """
+        # ARRANGE & ACT
+        resultat = ValidationResult(
+            is_valid=False,
+            errors=["Erreur 1", "Erreur 2"],
+            warnings=["Warning 1"],
+            validated_data=None
+        )
+
+        # ASSERT
+        assert resultat.is_valid is False
+        assert len(resultat.errors) == 2
+        assert len(resultat.warnings) == 1
+        assert resultat.validated_data is None
+
+    def test_valeurs_par_defaut(self):
+        """
+        Test 3: Les listes errors et warnings sont vides par défaut
+        """
+        # ARRANGE & ACT
+        resultat = ValidationResult(is_valid=True)
+
+        # ASSERT
+        assert resultat.errors == []
+        assert resultat.warnings == []
+
+
+# =============================================================================
+#                Tests pour EnumWarningCollector
+# =============================================================================
+
+class TestEnumWarningCollector:
+    """Tests pour le collecteur de warnings enum"""
+
+    def test_initialisation_vide(self):
+        """
+        Test 1: Le collecteur est vide à l'initialisation
+        """
+        # ARRANGE & ACT
+        collector = EnumWarningCollector()
+
+        # ASSERT
+        assert collector.warnings == []
+
+    def test_check_enum_valeurs_valides(self):
+        """
+        Test 2: Pas de warning si les valeurs sont dans la liste autorisée
+        """
+        # ARRANGE
+        collector = EnumWarningCollector()
+        series = pd.Series(['actif', 'inactif'])
+        allowed = ['actif', 'inactif', 'suspendu']
+
+        # ACT
+        collector.check_enum(series, allowed, 'status', 'Statut')
+
+        # ASSERT
+        assert collector.warnings == []
+
+    def test_check_enum_valeur_non_standard(self):
+        """
+        Test 3: Warning généré si une valeur n'est pas dans la liste
+        """
+        # ARRANGE
+        collector = EnumWarningCollector()
+        series = pd.Series(['actif', 'inconnu'])  # 'inconnu' n'est pas autorisé
+        allowed = ['actif', 'inactif', 'suspendu']
+
+        # ACT
+        collector.check_enum(series, allowed, 'status', 'Statut')
+
+        # ASSERT
+        assert len(collector.warnings) == 1
+        assert 'inconnu' in collector.warnings[0]
+        assert 'Statut' in collector.warnings[0]
+
+    def test_check_enum_valeurs_nulles_ignorees(self):
+        """
+        Test 4: Les valeurs nulles ne génèrent pas de warning
+        """
+        # ARRANGE
+        collector = EnumWarningCollector()
+        series = pd.Series(['actif', None, ''])
+        allowed = ['actif', 'inactif']
+
+        # ACT
+        collector.check_enum(series, allowed, 'status', 'Statut')
+
+        # ASSERT
+        assert collector.warnings == []
+
+    def test_clear_reinitialise(self):
+        """
+        Test 5: La méthode clear() vide les warnings
+        """
+        # ARRANGE
+        collector = EnumWarningCollector()
+        series = pd.Series(['inconnu'])
+        collector.check_enum(series, ['valide'], 'field', 'Field')
+        assert len(collector.warnings) == 1
+
+        # ACT
+        collector.clear()
+
+        # ASSERT
+        assert collector.warnings == []
+
+    def test_warnings_retourne_copie(self):
+        """
+        Test 6: La propriété warnings retourne une copie (pas la liste originale)
+        """
+        # ARRANGE
+        collector = EnumWarningCollector()
+        series = pd.Series(['inconnu'])
+        collector.check_enum(series, ['valide'], 'field', 'Field')
+
+        # ACT
+        warnings = collector.warnings
+        warnings.append("Nouveau warning")
+
+        # ASSERT - La liste interne n'est pas modifiée
+        assert len(collector.warnings) == 1
+
+
+# =============================================================================
+#                Tests pour create_enum_check_warning()
+# =============================================================================
+
+class TestCreateEnumCheckWarning:
+    """Tests pour la création de checks enum en mode WARNING"""
+
+    def test_check_retourne_toujours_vrai(self):
+        """
+        Test 1: Le check retourne toujours True (pas de blocage)
+        """
+        # ARRANGE
+        check = create_enum_check_warning(['a', 'b', 'c'], 'field_name')
+        series = pd.Series(['a', 'b', 'invalide'])  # 'invalide' n'est pas dans la liste
+
+        # ACT
+        resultat = check._check_fn(series)
+
+        # ASSERT - Toujours True car mode WARNING
+        assert resultat.all()
+
+    def test_check_a_un_nom(self):
+        """
+        Test 2: Le check a un nom descriptif
+        """
+        # ARRANGE & ACT
+        check = create_enum_check_warning(['a', 'b'], 'mon_champ')
+
+        # ASSERT
+        assert 'enum_warning_mon_champ' in check.name
+
+
+# =============================================================================
+#                Tests pour create_enum_column()
+# =============================================================================
+
+class TestCreateEnumColumn:
+    """Tests pour la création de colonnes enum"""
+
+    def test_creation_colonne_mode_strict(self):
+        """
+        Test 1: Mode STRICT - erreur si valeur hors liste
+        """
+        # ARRANGE & ACT
+        column = create_enum_column(
+            'status',
+            ['actif', 'inactif'],
+            mode=ValidationMode.STRICT
+        )
+
+        # ASSERT
+        assert isinstance(column, Column)
+
+    def test_creation_colonne_mode_warning(self):
+        """
+        Test 2: Mode WARNING - pas de blocage
+        """
+        # ARRANGE & ACT
+        column = create_enum_column(
+            'status',
+            ['actif', 'inactif'],
+            mode=ValidationMode.WARNING
+        )
+
+        # ASSERT
+        assert isinstance(column, Column)
+
+    def test_colonne_nullable_par_defaut(self):
+        """
+        Test 3: La colonne est nullable par défaut
+        """
+        # ARRANGE & ACT
+        column = create_enum_column('field', ['a', 'b'])
+
+        # ASSERT
+        assert column.nullable is True
+
+    def test_colonne_non_nullable(self):
+        """
+        Test 4: La colonne peut être configurée comme non nullable
+        """
+        # ARRANGE & ACT
+        column = create_enum_column('field', ['a', 'b'], nullable=False)
+
+        # ASSERT
+        assert column.nullable is False
+
+    def test_mode_warning_par_defaut(self):
+        """
+        Test 5: Le mode WARNING est utilisé par défaut
+        """
+        # ARRANGE & ACT
+        column = create_enum_column('field', ['a', 'b'])
+
+        # ASSERT - En mode WARNING, le check ne bloque pas
+        # On vérifie que le check a le nom "enum_warning_"
+        check_names = [c.name for c in column.checks]
+        assert any('enum_warning' in name for name in check_names)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,0 +1,391 @@
+"""
+Tests unitaires pour l'intégration Pandera (src/validation/integration.py)
+
+Ce module fait le pont entre les schémas UI et la validation Pandera.
+"""
+import pytest
+import pandas as pd
+from unittest.mock import MagicMock, patch
+from pandera import DataFrameSchema
+
+from src.validation.base import ValidationMode, ValidationResult
+from src.validation.integration import (
+    SchemaConverter,
+    validate_for_crud,
+    validate_dataframe,
+    WIDGET_TO_PANDERA,
+)
+
+
+# =============================================================================
+#                Tests pour WIDGET_TO_PANDERA (mapping)
+# =============================================================================
+
+class TestWidgetToPanderaMapping:
+    """Tests pour le mapping des widgets vers les types Pandera"""
+
+    def test_text_input_vers_string(self):
+        """Test: TEXT_INPUT → pa.String"""
+        from src.schema.definitions import WidgetType
+        import pandera as pa
+
+        assert WIDGET_TO_PANDERA[WidgetType.TEXT_INPUT] == pa.String
+
+    def test_number_input_vers_float(self):
+        """Test: NUMBER_INPUT → pa.Float"""
+        from src.schema.definitions import WidgetType
+        import pandera as pa
+
+        assert WIDGET_TO_PANDERA[WidgetType.NUMBER_INPUT] == pa.Float
+
+    def test_checkbox_vers_bool(self):
+        """Test: CHECKBOX → pa.Bool"""
+        from src.schema.definitions import WidgetType
+        import pandera as pa
+
+        assert WIDGET_TO_PANDERA[WidgetType.CHECKBOX] == pa.Bool
+
+    def test_date_input_vers_datetime(self):
+        """Test: DATE_INPUT → pa.DateTime"""
+        from src.schema.definitions import WidgetType
+        import pandera as pa
+
+        assert WIDGET_TO_PANDERA[WidgetType.DATE_INPUT] == pa.DateTime
+
+
+# =============================================================================
+#                Tests pour SchemaConverter
+# =============================================================================
+
+class TestSchemaConverter:
+    """Tests pour le convertisseur EntitySchema → DataFrameSchema"""
+
+    @pytest.fixture
+    def mock_entity_schema(self):
+        """Créer un EntitySchema mock pour les tests"""
+        from src.schema.definitions import EntitySchema, FieldSchema, WidgetType
+
+        fields = [
+            FieldSchema(
+                name="nom",
+                label="Nom",
+                widget=WidgetType.TEXT_INPUT,
+                required=True,
+                max_chars=100
+            ),
+            FieldSchema(
+                name="age",
+                label="Âge",
+                widget=WidgetType.NUMBER_INPUT,
+                required=False,
+                min_value=0,
+                max_value=150
+            ),
+            FieldSchema(
+                name="actif",
+                label="Actif",
+                widget=WidgetType.CHECKBOX,
+                required=False
+            ),
+        ]
+
+        return EntitySchema(
+            name="test_entity",
+            table_name="test_table",
+            display_name="Test Entity",
+            fields=fields
+        )
+
+    def test_build_schema_cree_dataframeschema(self, mock_entity_schema):
+        """
+        Test 1: build_schema() retourne un DataFrameSchema
+        """
+        # ARRANGE
+        converter = SchemaConverter(mock_entity_schema)
+
+        # ACT
+        schema = converter.build_schema()
+
+        # ASSERT
+        assert isinstance(schema, DataFrameSchema)
+
+    def test_build_schema_contient_colonnes(self, mock_entity_schema):
+        """
+        Test 2: Le schéma contient les colonnes définies
+        """
+        # ARRANGE
+        converter = SchemaConverter(mock_entity_schema)
+
+        # ACT
+        schema = converter.build_schema()
+
+        # ASSERT
+        assert 'nom' in schema.columns
+        assert 'age' in schema.columns
+        assert 'actif' in schema.columns
+
+    def test_build_schema_exclut_colonnes(self, mock_entity_schema):
+        """
+        Test 3: Les colonnes exclues ne sont pas dans le schéma
+        """
+        # ARRANGE
+        converter = SchemaConverter(mock_entity_schema)
+
+        # ACT
+        schema = converter.build_schema(exclude_fields={'age'})
+
+        # ASSERT
+        assert 'nom' in schema.columns
+        assert 'age' not in schema.columns
+
+    def test_build_schema_ignore_timestamps(self, mock_entity_schema):
+        """
+        Test 4: Les colonnes created_at et updated_at sont ignorées
+        """
+        # ARRANGE
+        from src.schema.definitions import FieldSchema, WidgetType
+
+        # Ajouter des champs timestamp
+        mock_entity_schema.fields.append(
+            FieldSchema(name="created_at", label="Créé le", widget=WidgetType.DATE_INPUT)
+        )
+        mock_entity_schema.fields.append(
+            FieldSchema(name="updated_at", label="Modifié le", widget=WidgetType.DATE_INPUT)
+        )
+
+        converter = SchemaConverter(mock_entity_schema)
+
+        # ACT
+        schema = converter.build_schema()
+
+        # ASSERT
+        assert 'created_at' not in schema.columns
+        assert 'updated_at' not in schema.columns
+
+    def test_validate_dict_valide(self, mock_entity_schema):
+        """
+        Test 5: validate_dict() avec données valides
+        """
+        # ARRANGE
+        converter = SchemaConverter(mock_entity_schema)
+        data = {
+            'nom': 'Alice',
+            'age': 25,
+            'actif': True
+        }
+
+        # ACT
+        with patch('src.validation.integration.enums', MagicMock()):
+            resultat = converter.validate_dict(data)
+
+        # ASSERT
+        assert isinstance(resultat, ValidationResult)
+        assert resultat.is_valid is True
+        assert resultat.errors == []
+
+    def test_validate_dict_champ_requis_manquant(self, mock_entity_schema):
+        """
+        Test 6: validate_dict() avec champ requis manquant
+        """
+        # ARRANGE
+        converter = SchemaConverter(mock_entity_schema)
+        data = {
+            'nom': '',  # Vide alors que requis
+            'age': 25
+        }
+
+        # ACT
+        with patch('src.validation.integration.enums', MagicMock()):
+            resultat = converter.validate_dict(data)
+
+        # ASSERT
+        assert resultat.is_valid is False
+        assert len(resultat.errors) > 0
+
+
+# =============================================================================
+#                Tests pour validate_for_crud()
+# =============================================================================
+
+class TestValidateForCrud:
+    """Tests pour la fonction utilitaire validate_for_crud"""
+
+    @pytest.fixture
+    def simple_entity_schema(self):
+        """Créer un EntitySchema simple"""
+        from src.schema.definitions import EntitySchema, FieldSchema, WidgetType
+
+        fields = [
+            FieldSchema(
+                name="titre",
+                label="Titre",
+                widget=WidgetType.TEXT_INPUT,
+                required=True
+            ),
+        ]
+
+        return EntitySchema(
+            name="article",
+            table_name="articles",
+            display_name="Article",
+            fields=fields
+        )
+
+    def test_validation_donnees_valides(self, simple_entity_schema):
+        """
+        Test 1: Données valides → is_valid=True
+        """
+        # ARRANGE
+        data = {'titre': 'Mon Article'}
+
+        # ACT
+        with patch('src.validation.integration.enums', MagicMock()):
+            resultat = validate_for_crud(simple_entity_schema, data)
+
+        # ASSERT
+        assert resultat.is_valid is True
+
+    def test_validation_donnees_invalides(self, simple_entity_schema):
+        """
+        Test 2: Données invalides → is_valid=False
+        """
+        # ARRANGE
+        data = {'titre': ''}  # Vide alors que requis
+
+        # ACT
+        with patch('src.validation.integration.enums', MagicMock()):
+            resultat = validate_for_crud(simple_entity_schema, data)
+
+        # ASSERT
+        assert resultat.is_valid is False
+
+    def test_validation_avec_exclusion(self, simple_entity_schema):
+        """
+        Test 3: Les champs exclus ne sont pas validés
+        """
+        # ARRANGE
+        data = {'titre': ''}  # Vide mais exclu
+
+        # ACT
+        with patch('src.validation.integration.enums', MagicMock()):
+            resultat = validate_for_crud(
+                simple_entity_schema,
+                data,
+                exclude_fields={'titre'}
+            )
+
+        # ASSERT - Pas d'erreur car le champ est exclu
+        assert resultat.is_valid is True
+
+
+# =============================================================================
+#                Tests pour validate_dataframe()
+# =============================================================================
+
+class TestValidateDataframe:
+    """Tests pour la validation de DataFrame complet"""
+
+    @pytest.fixture
+    def df_schema(self):
+        """Créer un EntitySchema pour DataFrame"""
+        from src.schema.definitions import EntitySchema, FieldSchema, WidgetType
+
+        fields = [
+            FieldSchema(
+                name="id",
+                label="ID",
+                widget=WidgetType.NUMBER_INPUT,
+                required=True
+            ),
+            FieldSchema(
+                name="valeur",
+                label="Valeur",
+                widget=WidgetType.TEXT_INPUT,
+                required=False
+            ),
+        ]
+
+        return EntitySchema(
+            name="data",
+            table_name="data_table",
+            display_name="Data",
+            fields=fields
+        )
+
+    def test_validation_dataframe_valide(self, df_schema):
+        """
+        Test 1: DataFrame entièrement valide
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'id': [1, 2, 3],
+            'valeur': ['a', 'b', 'c']
+        })
+
+        # ACT
+        with patch('src.validation.integration.enums', MagicMock()):
+            resultat = validate_dataframe(df_schema, df)
+
+        # ASSERT
+        assert resultat.is_valid is True
+        assert resultat.validated_data is not None
+
+    def test_validation_dataframe_avec_erreurs(self, df_schema):
+        """
+        Test 2: DataFrame avec des erreurs
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'id': [1, None, 3],  # None dans un champ requis
+            'valeur': ['a', 'b', 'c']
+        })
+
+        # ACT
+        with patch('src.validation.integration.enums', MagicMock()):
+            resultat = validate_dataframe(df_schema, df)
+
+        # ASSERT
+        # Le résultat dépend de la configuration du schéma
+        assert isinstance(resultat, ValidationResult)
+
+
+# =============================================================================
+#                Tests pour ValidationResult
+# =============================================================================
+
+class TestValidationResultIntegration:
+    """Tests d'intégration pour ValidationResult"""
+
+    def test_resultat_contient_warnings(self):
+        """
+        Test: Le résultat peut contenir des warnings sans erreurs
+        """
+        # ARRANGE & ACT
+        resultat = ValidationResult(
+            is_valid=True,
+            errors=[],
+            warnings=["Valeur non standard détectée"],
+            validated_data=pd.DataFrame({'col': [1]})
+        )
+
+        # ASSERT
+        assert resultat.is_valid is True
+        assert len(resultat.warnings) == 1
+        assert len(resultat.errors) == 0
+
+    def test_resultat_erreurs_et_warnings(self):
+        """
+        Test: Le résultat peut avoir à la fois erreurs et warnings
+        """
+        # ARRANGE & ACT
+        resultat = ValidationResult(
+            is_valid=False,
+            errors=["Champ requis manquant"],
+            warnings=["Valeur non standard"],
+            validated_data=None
+        )
+
+        # ASSERT
+        assert resultat.is_valid is False
+        assert len(resultat.errors) == 1
+        assert len(resultat.warnings) == 1

--- a/test/test_schema_validation.py
+++ b/test/test_schema_validation.py
@@ -1,0 +1,259 @@
+"""
+Tests unitaires pour la validation de schémas (src/validation/schema_validation.py)
+
+Ces fonctions construisent des schémas Pandera et valident des fichiers CSV.
+"""
+import pytest
+import pandas as pd
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from pandera import DataFrameSchema
+from src.validation.schema_validation import build_dataframe_schema, valider_csv
+
+
+# =============================================================================
+#                Tests pour build_dataframe_schema()
+# =============================================================================
+
+class TestBuildDataframeSchema:
+    """Tests pour la construction de schémas Pandera"""
+
+    def test_schema_simple_avec_types(self):
+        """
+        Test 1: Créer un schéma avec différents types de colonnes
+        """
+        # ARRANGE - Définition du schéma
+        schema_dict = {
+            'id': {'type': 'int', 'nullable': False},
+            'nom': {'type': 'str', 'nullable': True},
+            'prix': {'type': 'float', 'nullable': True}
+        }
+
+        # ACT
+        schema = build_dataframe_schema(schema_dict)
+
+        # ASSERT
+        assert isinstance(schema, DataFrameSchema)
+        assert 'id' in schema.columns
+        assert 'nom' in schema.columns
+        assert 'prix' in schema.columns
+
+    def test_schema_avec_check_greater_than(self):
+        """
+        Test 2: Schéma avec une contrainte "greater_than"
+        """
+        # ARRANGE
+        schema_dict = {
+            'age': {
+                'type': 'int',
+                'nullable': True,
+                'checks': [{'greater_than': 0}]
+            }
+        }
+
+        # ACT
+        schema = build_dataframe_schema(schema_dict)
+
+        # ASSERT - Vérifions que le schéma valide correctement
+        df_valide = pd.DataFrame({'age': [25, 30]})
+        resultat = schema.validate(df_valide)
+        assert len(resultat) == 2
+
+    def test_schema_avec_check_less_than(self):
+        """
+        Test 3: Schéma avec une contrainte "less_than"
+        """
+        # ARRANGE
+        schema_dict = {
+            'score': {
+                'type': 'int',
+                'nullable': True,
+                'checks': [{'less_than': 100}]
+            }
+        }
+
+        # ACT
+        schema = build_dataframe_schema(schema_dict)
+
+        # ASSERT
+        df_valide = pd.DataFrame({'score': [50, 99]})
+        resultat = schema.validate(df_valide)
+        assert len(resultat) == 2
+
+    def test_schema_avec_check_isin(self):
+        """
+        Test 4: Schéma avec une contrainte "isin" (valeurs autorisées)
+        """
+        # ARRANGE
+        schema_dict = {
+            'status': {
+                'type': 'str',
+                'nullable': True,
+                'checks': [{'isin': ['actif', 'inactif', 'en_attente']}]
+            }
+        }
+
+        # ACT
+        schema = build_dataframe_schema(schema_dict)
+
+        # ASSERT
+        df_valide = pd.DataFrame({'status': ['actif', 'inactif']})
+        resultat = schema.validate(df_valide)
+        assert len(resultat) == 2
+
+    def test_schema_avec_unique(self):
+        """
+        Test 5: Schéma avec contrainte d'unicité
+        """
+        # ARRANGE
+        schema_dict = {
+            'id': {
+                'type': 'int',
+                'nullable': False,
+                'unique': True
+            }
+        }
+
+        # ACT
+        schema = build_dataframe_schema(schema_dict)
+
+        # ASSERT
+        df_valide = pd.DataFrame({'id': [1, 2, 3]})
+        resultat = schema.validate(df_valide)
+        assert len(resultat) == 3
+
+    def test_schema_strict_mode(self):
+        """
+        Test 6: Schéma en mode strict (colonnes supplémentaires interdites)
+        """
+        # ARRANGE
+        schema_dict = {
+            'nom': {'type': 'str', 'nullable': True}
+        }
+
+        # ACT
+        schema = build_dataframe_schema(schema_dict, strict_method=True)
+
+        # ASSERT
+        assert schema.strict is True
+
+
+# =============================================================================
+#                Tests pour valider_csv()
+# =============================================================================
+
+class TestValiderCsv:
+    """Tests pour la validation de fichiers CSV"""
+
+    def test_validation_csv_valide(self, tmp_path):
+        """
+        Test 1: Validation d'un CSV entièrement valide
+        """
+        # ARRANGE - Créer un fichier CSV temporaire
+        csv_file = tmp_path / "test.csv"
+        df = pd.DataFrame({
+            'id': [1, 2, 3],
+            'nom': ['Alice', 'Bob', 'Charlie']
+        })
+        df.to_csv(csv_file, index=False)
+
+        # Créer un schéma simple
+        schema_dict = {
+            'id': {'type': 'int', 'nullable': False},
+            'nom': {'type': 'str', 'nullable': True}
+        }
+        schema = build_dataframe_schema(schema_dict)
+
+        # Créer les répertoires de sortie
+        (tmp_path / "data" / "raw_valid").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "data" / "raw_rejected").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "data" / "raw_errors").mkdir(parents=True, exist_ok=True)
+
+        # ACT - Valider avec patch des chemins
+        with patch('src.validation.schema_validation.Path') as mock_path:
+            # Simuler les chemins
+            mock_path.return_value = csv_file
+            mock_path.side_effect = lambda x: Path(tmp_path) / x if "data/" in str(x) else Path(x)
+
+            resultat = valider_csv(csv_file, schema, lazy=True)
+
+        # ASSERT
+        assert isinstance(resultat, pd.DataFrame)
+        assert len(resultat) == 3
+
+    def test_validation_csv_avec_erreurs(self, tmp_path):
+        """
+        Test 2: Validation d'un CSV avec des lignes invalides
+        Les lignes invalides sont séparées dans un fichier rejeté
+        """
+        # ARRANGE
+        csv_file = tmp_path / "test_errors.csv"
+        df = pd.DataFrame({
+            'id': [1, 'invalid', 3],  # 'invalid' n'est pas un int
+            'nom': ['Alice', 'Bob', 'Charlie']
+        })
+        df.to_csv(csv_file, index=False)
+
+        schema_dict = {
+            'id': {'type': 'int', 'nullable': False},
+            'nom': {'type': 'str', 'nullable': True}
+        }
+        schema = build_dataframe_schema(schema_dict)
+
+        # Créer les répertoires
+        for subdir in ['raw_valid', 'raw_rejected', 'raw_errors']:
+            (tmp_path / "data" / subdir).mkdir(parents=True, exist_ok=True)
+
+        # ACT
+        with patch('src.validation.schema_validation.Path') as mock_path:
+            mock_path.return_value = csv_file
+            mock_path.side_effect = lambda x: Path(tmp_path) / x if "data/" in str(x) else Path(x)
+
+            resultat = valider_csv(csv_file, schema, lazy=True)
+
+        # ASSERT - Le résultat contient les lignes valides
+        assert isinstance(resultat, pd.DataFrame)
+
+
+# =============================================================================
+#                Tests de validation de types
+# =============================================================================
+
+class TestTypeValidation:
+    """Tests pour la validation des types de données"""
+
+    def test_type_int(self):
+        """Test: type int correctement validé"""
+        schema_dict = {'col': {'type': 'int', 'nullable': True}}
+        schema = build_dataframe_schema(schema_dict)
+
+        df = pd.DataFrame({'col': [1, 2, 3]})
+        resultat = schema.validate(df)
+        assert len(resultat) == 3
+
+    def test_type_str(self):
+        """Test: type str correctement validé"""
+        schema_dict = {'col': {'type': 'str', 'nullable': True}}
+        schema = build_dataframe_schema(schema_dict)
+
+        df = pd.DataFrame({'col': ['a', 'b', 'c']})
+        resultat = schema.validate(df)
+        assert len(resultat) == 3
+
+    def test_type_float(self):
+        """Test: type float correctement validé"""
+        schema_dict = {'col': {'type': 'float', 'nullable': True}}
+        schema = build_dataframe_schema(schema_dict)
+
+        df = pd.DataFrame({'col': [1.5, 2.7, 3.9]})
+        resultat = schema.validate(df)
+        assert len(resultat) == 3
+
+    def test_type_bool(self):
+        """Test: type bool correctement validé"""
+        schema_dict = {'col': {'type': 'bool', 'nullable': True}}
+        schema = build_dataframe_schema(schema_dict)
+
+        df = pd.DataFrame({'col': [True, False, True]})
+        resultat = schema.validate(df)
+        assert len(resultat) == 3

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -1,0 +1,397 @@
+"""
+Tests unitaires pour les validateurs cross-field (src/validation/validators.py)
+
+Ces fonctions vérifient des règles métier impliquant plusieurs champs.
+"""
+import pytest
+import pandas as pd
+from src.validation.validators import (
+    coordinates_check,
+    coordinates_in_france,
+    resultat_humain_coherence,
+    flotteur_longueur_type_coherence,
+    beaufort_scale_check,
+    douglas_scale_check,
+    departement_format_check,
+)
+
+
+# =============================================================================
+#                Tests pour coordinates_check()
+# =============================================================================
+
+class TestCoordinatesCheck:
+    """Tests pour la validation de cohérence latitude/longitude"""
+
+    def test_coordonnees_valides_toutes_presentes(self):
+        """
+        Test 1: latitude et longitude sont toutes les deux présentes
+        → Doit être valide
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'latitude': [48.8566, 45.764],
+            'longitude': [2.3522, 4.8357]
+        })
+        check = coordinates_check()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat is True
+
+    def test_coordonnees_valides_toutes_absentes(self):
+        """
+        Test 2: latitude et longitude sont toutes les deux absentes (NULL)
+        → Doit être valide
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'latitude': [None, None],
+            'longitude': [None, None]
+        })
+        check = coordinates_check()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat is True
+
+    def test_coordonnees_invalides_latitude_seule(self):
+        """
+        Test 3: latitude présente mais longitude absente
+        → Doit être invalide
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'latitude': [48.8566, None],
+            'longitude': [None, None]
+        })
+        check = coordinates_check()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat is False
+
+    def test_colonnes_absentes(self):
+        """
+        Test 4: Colonnes latitude/longitude absentes du DataFrame
+        → Doit retourner True (pas d'erreur)
+        """
+        # ARRANGE
+        df = pd.DataFrame({'autre_colonne': [1, 2, 3]})
+        check = coordinates_check()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat is True
+
+
+# =============================================================================
+#                Tests pour coordinates_in_france()
+# =============================================================================
+
+class TestCoordinatesInFrance:
+    """Tests pour la validation géographique (zone France)"""
+
+    def test_coordonnees_france_metropolitaine(self):
+        """
+        Test 1: Coordonnées dans la France métropolitaine
+        → Doit être valide
+        """
+        # ARRANGE - Paris
+        df = pd.DataFrame({
+            'latitude': [48.8566],
+            'longitude': [2.3522]
+        })
+        check = coordinates_in_france()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat.all()
+
+    def test_coordonnees_reunion(self):
+        """
+        Test 2: Coordonnées à la Réunion
+        → Doit être valide
+        """
+        # ARRANGE - La Réunion
+        df = pd.DataFrame({
+            'latitude': [-21.1151],
+            'longitude': [55.5364]
+        })
+        check = coordinates_in_france()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat.all()
+
+    def test_coordonnees_hors_france(self):
+        """
+        Test 3: Coordonnées hors zone France (New York)
+        → Doit être invalide
+        """
+        # ARRANGE - New York
+        df = pd.DataFrame({
+            'latitude': [40.7128],
+            'longitude': [-74.0060]
+        })
+        check = coordinates_in_france()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert not resultat.all()
+
+    def test_coordonnees_nulles(self):
+        """
+        Test 4: Coordonnées nulles
+        → Doit être valide (null autorisé)
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'latitude': [None],
+            'longitude': [None]
+        })
+        check = coordinates_in_france()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat.all()
+
+
+# =============================================================================
+#                Tests pour beaufort_scale_check()
+# =============================================================================
+
+class TestBeaufortScaleCheck:
+    """Tests pour l'échelle de Beaufort (force du vent 0-12)"""
+
+    def test_valeur_valide_minimum(self):
+        """Test avec la valeur minimum (0)"""
+        check = beaufort_scale_check()
+        assert check._check_fn(0) is True
+
+    def test_valeur_valide_maximum(self):
+        """Test avec la valeur maximum (12)"""
+        check = beaufort_scale_check()
+        assert check._check_fn(12) is True
+
+    def test_valeur_valide_milieu(self):
+        """Test avec une valeur au milieu (6)"""
+        check = beaufort_scale_check()
+        assert check._check_fn(6) is True
+
+    def test_valeur_invalide_trop_haute(self):
+        """Test avec une valeur trop haute (13)"""
+        check = beaufort_scale_check()
+        assert check._check_fn(13) is False
+
+    def test_valeur_invalide_negative(self):
+        """Test avec une valeur négative (-1)"""
+        check = beaufort_scale_check()
+        assert check._check_fn(-1) is False
+
+    def test_valeur_nulle(self):
+        """Test avec une valeur nulle (None)"""
+        check = beaufort_scale_check()
+        assert check._check_fn(None) is True
+
+
+# =============================================================================
+#                Tests pour douglas_scale_check()
+# =============================================================================
+
+class TestDouglasScaleCheck:
+    """Tests pour l'échelle de Douglas (force de la mer 0-9)"""
+
+    def test_valeur_valide_minimum(self):
+        """Test avec la valeur minimum (0)"""
+        check = douglas_scale_check()
+        assert check._check_fn(0) is True
+
+    def test_valeur_valide_maximum(self):
+        """Test avec la valeur maximum (9)"""
+        check = douglas_scale_check()
+        assert check._check_fn(9) is True
+
+    def test_valeur_invalide_trop_haute(self):
+        """Test avec une valeur trop haute (10)"""
+        check = douglas_scale_check()
+        assert check._check_fn(10) is False
+
+    def test_valeur_nulle(self):
+        """Test avec une valeur nulle"""
+        check = douglas_scale_check()
+        assert check._check_fn(None) is True
+
+
+# =============================================================================
+#                Tests pour departement_format_check()
+# =============================================================================
+
+class TestDepartementFormatCheck:
+    """Tests pour le format du département (2-3 caractères)"""
+
+    def test_departement_valide_deux_chiffres(self):
+        """Test avec un département à 2 chiffres (75 - Paris)"""
+        check = departement_format_check()
+        assert check._check_fn("75") is True
+
+    def test_departement_valide_trois_chiffres(self):
+        """Test avec un département à 3 chiffres (971 - Guadeloupe)"""
+        check = departement_format_check()
+        assert check._check_fn("971") is True
+
+    def test_departement_valide_corse(self):
+        """Test avec la Corse (2A)"""
+        check = departement_format_check()
+        assert check._check_fn("2A") is True
+
+    def test_departement_invalide_trop_long(self):
+        """Test avec un code trop long"""
+        check = departement_format_check()
+        assert check._check_fn("12345") is False
+
+    def test_departement_vide(self):
+        """Test avec une chaîne vide"""
+        check = departement_format_check()
+        assert check._check_fn("") is True
+
+    def test_departement_null(self):
+        """Test avec None"""
+        check = departement_format_check()
+        assert check._check_fn(None) is True
+
+
+# =============================================================================
+#                Tests pour resultat_humain_coherence()
+# =============================================================================
+
+class TestResultatHumainCoherence:
+    """Tests pour la cohérence resultat_humain / nombre de personnes"""
+
+    def test_coherence_valide_avec_resultat_et_nombre(self):
+        """
+        Test: Si un résultat est spécifié, le nombre doit être >= 1
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'resultat_humain': ['Sauvé', 'Décédé'],
+            'nombre': [5, 1]
+        })
+        check = resultat_humain_coherence()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat is True
+
+    def test_coherence_invalide_resultat_sans_nombre(self):
+        """
+        Test: Résultat spécifié mais nombre = 0
+        → Doit être invalide
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'resultat_humain': ['Sauvé'],
+            'nombre': [0]
+        })
+        check = resultat_humain_coherence()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat is False
+
+    def test_coherence_valide_sans_resultat(self):
+        """
+        Test: Pas de résultat, nombre peut être 0
+        → Doit être valide
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'resultat_humain': [None, ''],
+            'nombre': [0, 0]
+        })
+        check = resultat_humain_coherence()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat is True
+
+
+# =============================================================================
+#                Tests pour flotteur_longueur_type_coherence()
+# =============================================================================
+
+class TestFlotteurLongueurTypeCoherence:
+    """Tests pour la cohérence type de flotteur / longueur"""
+
+    def test_kayak_longueur_valide(self):
+        """
+        Test: Un kayak de 4m est valide (max 6m)
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'type_flotteur': ['Canoe/Kayak'],
+            'longueur': [4.0]
+        })
+        check = flotteur_longueur_type_coherence()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat.all()
+
+    def test_kayak_longueur_invalide(self):
+        """
+        Test: Un kayak de 10m est invalide (max 6m)
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'type_flotteur': ['Canoe/Kayak'],
+            'longueur': [10.0]
+        })
+        check = flotteur_longueur_type_coherence()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert not resultat.all()
+
+    def test_longueur_nulle_toujours_valide(self):
+        """
+        Test: Une longueur nulle est toujours valide
+        """
+        # ARRANGE
+        df = pd.DataFrame({
+            'type_flotteur': ['Jet-ski'],
+            'longueur': [None]
+        })
+        check = flotteur_longueur_type_coherence()
+
+        # ACT
+        resultat = check._check_fn(df)
+
+        # ASSERT
+        assert resultat.all()


### PR DESCRIPTION
- Implement unit tests for base validation classes in `test/test_base.py`.
- Add integration tests for Pandera schema validation in `test/test_integration.py`.
- Create tests for schema building and CSV validation in `test/test_schema_validation.py`.
- Introduce cross-field validators tests in `test/test_validators.py`.
- Ensure comprehensive coverage for validation modes, results, and various checks.